### PR TITLE
Arreglando Tags y agregando gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Django stuffs
+*.log
+db.sqlite3
+db.sqlite3-journal
+__pycache__/
+
+# Virtual Enviroment
+*env/
+.python-version
+
+# Pdf files
+*.pdf
+
+# Enviroment Variables
+*.yaml
+

--- a/elotl/views.py
+++ b/elotl/views.py
@@ -1,5 +1,5 @@
 import logging
-from git import Repo
+from git import Repo, exc
 from django.shortcuts import render
 from corpus_admin.helpers import get_corpus_info, get_variants
 from django.http import FileResponse, Http404
@@ -86,9 +86,15 @@ def about(request):
     """
     LOGGER.info("Entrando a about")
     total, docs = get_corpus_info()
-    version = Repo('./').tags[-1]
+    try:
+        repo = Repo('.')
+        commits = list(repo.iter_commits('master'))
+        last_commit = commits[0].hexsha
+    except exc.InvalidGitRepositoryError:
+        LOGGER.error("No se encontró repositorio de git")
+        last_commit = ""
     return render(request, "about.html",
-                  {"total": total, "docs": docs, "version": version})
+                  {"total": total, "docs": docs, "commit": last_commit})
 
 # === Participantes ===
 

--- a/templates/about.html
+++ b/templates/about.html
@@ -55,10 +55,12 @@
         </table>
       </div>
     </div>
+    {% if commit %}
     <div class="row">
       <div class="col-12">
-        <p class="text-right text-monospace">Versión: <b>{{ version }}</b></p>
+        <p class="text-right text-monospace"><i class="fa fa-github"></i> <b>{{ commit|slice:":7" }}</b></p>
       </div>
     </div>
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Se agrega el archivo gitignore y se reparan los problemas con los tags del repo en las vistas de about. Se opta por mostrar el último commit y se agregan excepciones en caso de que no exista repositorio en el proyecto.