### PR TITLE
fix(bug): Links de pdf rotos

### DIFF
--- a/corpus_admin/helpers.py
+++ b/corpus_admin/helpers.py
@@ -46,11 +46,8 @@ def get_corpus_info():
     for bucket in buckets:
         total += int(bucket["doc_count"])
         document = get_document_info(bucket['key'])
-        doc_description = {
-            'file': document['file'], 'name': document['name'],
-            'id': bucket['key'], 'count': bucket['doc_count']
-        }
-        docs.append(doc_description)
+        document['count'] = bucket['doc_count']
+        docs.append(document)
     return total, docs
 
 # === Cargador de PDFs ===

--- a/esquite/urls.py
+++ b/esquite/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path('links/', views.links, name='links'),
     path('about/', views.about, name='about'),
     path('participantes/', views.participants, name='participantes'),
-    path('media/<path:file_name>/', views.pdf_view, name="pdf_view"),
+    path('media/<path:file_name>', views.pdf_view, name="pdf_view"),
     path('admin/', admin.site.urls),
     path('search/', include('searcher.urls')),
     path('corpus-admin/', include('corpus_admin.urls')),


### PR DESCRIPTION
Se modifica la URL para que no agrege un `/` al final. Close #42