### PR TITLE
Arregla exportar corpus desde el Admin

### DIFF
--- a/corpus_admin/views.py
+++ b/corpus_admin/views.py
@@ -138,7 +138,7 @@ def doc_edit(request, _id):
                 a <b>{doc_name}</b>."""
                 messages.add_message(request, messages.WARNING, notification)
             else:
-                set_name = False
+                set_name = ''
 
             if data_form['pdf'] is not None:
                 pdf_name = data_form['pdf'].name
@@ -148,7 +148,7 @@ def doc_edit(request, _id):
                 cambió a <b>{pdf_name}</b>."""
                 messages.add_message(request, messages.WARNING, notification)
             else:
-                set_file = False
+                set_file = ''
 
             if set_file or set_name:
                 update_rules = {

--- a/corpus_admin/views.py
+++ b/corpus_admin/views.py
@@ -130,21 +130,25 @@ def doc_edit(request, _id):
         form = DocumentEditForm(request.POST, request.FILES)
         if form.is_valid():
             data_form = form.cleaned_data
-            set_name, set_file = '', ''
             # Script que se ejecutara en Elasticsearch
-            base_script = "ctx._source.put('document_"
             if data_form['nombre'] != '':
-                set_name = base_script + f"name', '{data_form['nombre']}');"
+                doc_name = data_form['nombre']
+                set_name = f"ctx._source.put('document_name', '{doc_name}');"
                 notification = f"""El documento <b>{_id}</b> cambió el nombre
-                a <b>{data_form['nombre']}</b>."""
+                a <b>{doc_name}</b>."""
                 messages.add_message(request, messages.WARNING, notification)
+            else:
+                set_name = False
 
             if data_form['pdf'] is not None:
-                set_file = base_script + f"file', '{data_form['pdf'].name}');"
-                pdf_uploader(data_form['pdf'], data_form['pdf'].name)
+                pdf_name = data_form['pdf'].name
+                set_file = f"ctx._source.put('pdf_file', '{pdf_name}');"
+                pdf_uploader(data_form['pdf'], pdf_name)
                 notification = f"""El archivo del documento <b>{_id}</b> PDF
-                cambió a <b>{data_form['pdf'].name}</b>."""
+                cambió a <b>{pdf_name}</b>."""
                 messages.add_message(request, messages.WARNING, notification)
+            else:
+                set_file = False
 
             if set_file or set_name:
                 update_rules = {
@@ -163,7 +167,7 @@ def doc_edit(request, _id):
             else:
                 notification = "Se debe modificar <b>al menos un campo</b>. " \
                                "Documento sin cambios :("
-                messages.add_message(request, messages.ERROR, notification)
+                messages.add_message(request, messages.WARNING, notification)
                 return HttpResponseRedirect('/corpus-admin/edit/' + _id)
     else:
         form = DocumentEditForm()

--- a/esquite/settings.py
+++ b/esquite/settings.py
@@ -172,7 +172,7 @@ STATICFILES_DIRS = [
 
 STATIC_ROOT = BASE_DIR + '/site/assets/'
 
-MEDIA_ROOT = BASE_DIR + '/media/'
+MEDIA_ROOT = '/media/'
 
 GOOGLE_ANALYTICS = {
     'google_analytics_id': env["GOOGLE_ANALYTICS"]

--- a/esquite/views.py
+++ b/esquite/views.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from git import Repo, exc
 from django.shortcuts import render
@@ -131,9 +132,8 @@ def pdf_view(request, file_name):
     :return: Archivo ``PDF`` para ser visto en el navegador
     """
     try:
-        return FileResponse(open(settings.BASE_DIR + settings.MEDIA_ROOT +
-                                 file_name, 'rb'),
-                            content_type='application/pdf')
+        path = settings.BASE_DIR + settings.MEDIA_ROOT + file_name
+        return FileResponse(open(path, 'rb'), content_type='application/pdf')
     except FileNotFoundError:
         path = settings.BASE_DIR + settings.MEDIA_ROOT + file_name
         LOGGER.error("No se encontro el PDF en " + path)

--- a/searcher/helpers.py
+++ b/searcher/helpers.py
@@ -200,7 +200,8 @@ def results_to_csv(data_response, variants):
     :rtype: bool
     """
     row = []
-    path_to_save = os.path.join(settings.MEDIA_ROOT,  "query-results.csv")
+    file_name = "query-results.csv"
+    path_to_save = settings.BASE_DIR + settings.MEDIA_ROOT + file_name
     query_results = data_response['hits']
     with open(path_to_save, "w") as csv_file:
         writer = csv.writer(csv_file)

--- a/searcher/views.py
+++ b/searcher/views.py
@@ -168,7 +168,7 @@ def download_results(request):
     :type: ``HttpRequest``
     :return: Los resultados de busqueda en formato ``csv``
     """
-    file_path = os.path.join(settings.MEDIA_ROOT, "query-results.csv")
+    file_path = settings.BASE_DIR + settings.MEDIA_ROOT + "query-results.csv"
     if os.path.exists(file_path):
         with open(file_path, 'r') as csv_file:
             data = csv_file.read()


### PR DESCRIPTION
Se corrige el error cuando no existia variante a la hora de exportar el corpus desde el administrador de corpus. Además se refactoriza código para la modificación de documentos y el despliegue de pdfs 